### PR TITLE
Migrate to route objects

### DIFF
--- a/apps/mobile/src/main/java/com/dpanger/vehicles/VehiclesApp.kt
+++ b/apps/mobile/src/main/java/com/dpanger/vehicles/VehiclesApp.kt
@@ -10,13 +10,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.dpanger.vehicles.features.makes.ui.ARG_MANUFACTURER_ID
+import androidx.navigation.toRoute
+import com.dpanger.vehicles.features.makes.ui.MakesRoute
 import com.dpanger.vehicles.features.makes.ui.MakesScreen
-import com.dpanger.vehicles.features.makes.ui.ROUTE_MAKES
-import com.dpanger.vehicles.features.makes.ui.forManufacturer
+import com.dpanger.vehicles.features.manufacturers.ui.ManufacturersRoute
 import com.dpanger.vehicles.features.manufacturers.ui.ManufacturersScreen
-import com.dpanger.vehicles.features.manufacturers.ui.ROUTE_MANUFACTURERS
-import com.dpanger.vehicles.features.search.ui.ROUTE_SEARCH
+import com.dpanger.vehicles.features.search.ui.SearchRoute
 import com.dpanger.vehicles.features.search.ui.SearchScreen
 import com.dpanger.vehicles.viewmodel.AppUiState
 import com.dpanger.vehicles.viewmodel.AppViewModel
@@ -36,7 +35,7 @@ fun VehiclesApp(
         is AppUiState.Success -> {
             val startDestination =
                 remember(uiState.isSearchEnabled) {
-                    if (uiState.isSearchEnabled) ROUTE_SEARCH else ROUTE_MANUFACTURERS
+                    if (uiState.isSearchEnabled) SearchRoute else ManufacturersRoute
                 }
 
             Surface(
@@ -48,26 +47,27 @@ fun VehiclesApp(
                     startDestination = startDestination,
                 ) {
                     if (uiState.isSearchEnabled) {
-                        composable(ROUTE_SEARCH) {
+                        composable<SearchRoute> {
                             SearchScreen(
                                 viewModel = hiltViewModel(),
                             )
                         }
                     } else {
-                        composable(ROUTE_MANUFACTURERS) {
+                        composable<ManufacturersRoute> {
                             ManufacturersScreen(
                                 viewModel = hiltViewModel(),
                                 onManufacturerClicked = { id ->
-                                    val route = forManufacturer(id)
+                                    val route = MakesRoute(id)
                                     navController.navigate(route)
                                 },
                             )
                         }
                     }
-                    composable(ROUTE_MAKES) { entry ->
+                    composable<MakesRoute> { entry ->
+                        val route = entry.toRoute<MakesRoute>()
                         MakesScreen(
                             viewModel = hiltViewModel(),
-                            manufacturerId = entry.arguments?.getString(ARG_MANUFACTURER_ID).orEmpty(),
+                            manufacturerId = route.manufacturerId,
                         )
                     }
                 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
     implementation(libs.kotlin.gradle)
     implementation(libs.ksp.gradle)
     implementation(libs.ktlint.gradle)
+    implementation(libs.serialization.gradle)
 }

--- a/build-logic/src/main/kotlin/com/dpanger/vehicles/recipes-application.gradle.kts
+++ b/build-logic/src/main/kotlin/com/dpanger/vehicles/recipes-application.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.google.dagger.hilt.android")
     kotlin("android")
     id("com.google.devtools.ksp")
+    kotlin("plugin.serialization")
 }
 
 android {
@@ -49,6 +50,10 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+
+    // Compose Navigation + Typesafe routes w/ Serialization
+    implementation("androidx.navigation:navigation-compose:2.8.7")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 
     val hiltVersion = "2.49"
     implementation("com.google.dagger:hilt-android:$hiltVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,5 +5,6 @@ plugins {
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.serialization) apply false
 }
 true

--- a/features/makes/build.gradle.kts
+++ b/features/makes/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("library-android-compose")
+    kotlin("plugin.serialization")
 }
 
 android {
@@ -19,6 +20,7 @@ dependencies {
 
     implementation(libs.core.ktx)
     implementation(libs.lifecycle.viewmodel)
+    implementation(libs.serialization)
 
     testImplementation(libs.bundles.testing)
 }

--- a/features/makes/src/main/java/com/dpanger/vehicles/features/makes/ui/MakesRoute.kt
+++ b/features/makes/src/main/java/com/dpanger/vehicles/features/makes/ui/MakesRoute.kt
@@ -1,0 +1,6 @@
+package com.dpanger.vehicles.features.makes.ui
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MakesRoute(val manufacturerId: String)

--- a/features/makes/src/main/java/com/dpanger/vehicles/features/makes/ui/Routes.kt
+++ b/features/makes/src/main/java/com/dpanger/vehicles/features/makes/ui/Routes.kt
@@ -1,8 +1,0 @@
-package com.dpanger.vehicles.features.makes.ui
-
-const val ROUTE_MAKES = "makes/{manufacturerId}"
-private const val ROUTE_MAKES_BASE = "makes/"
-
-const val ARG_MANUFACTURER_ID = "manufacturerId"
-
-fun forManufacturer(id: String) = ROUTE_MAKES_BASE + id

--- a/features/manufacturers/build.gradle.kts
+++ b/features/manufacturers/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("library-android-compose")
+    kotlin("plugin.serialization")
 }
 
 android {
@@ -19,6 +20,7 @@ dependencies {
 
     implementation(libs.core.ktx)
     implementation(libs.lifecycle.viewmodel)
+    implementation(libs.serialization)
 
     testImplementation(libs.bundles.testing)
 }

--- a/features/manufacturers/src/main/java/com/dpanger/vehicles/features/manufacturers/ui/ManufacturersRoute.kt
+++ b/features/manufacturers/src/main/java/com/dpanger/vehicles/features/manufacturers/ui/ManufacturersRoute.kt
@@ -1,0 +1,6 @@
+package com.dpanger.vehicles.features.manufacturers.ui
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object ManufacturersRoute

--- a/features/manufacturers/src/main/java/com/dpanger/vehicles/features/manufacturers/ui/ManufacturersScreen.kt
+++ b/features/manufacturers/src/main/java/com/dpanger/vehicles/features/manufacturers/ui/ManufacturersScreen.kt
@@ -8,8 +8,6 @@ import com.dpanger.vehicles.features.manufacturers.viewmodel.ManufacturersViewMo
 import com.dpanger.vehicles.uicomponents.components.error.ErrorMessage
 import com.dpanger.vehicles.uicomponents.components.progress.ProgressIndicator
 
-const val ROUTE_MANUFACTURERS = "manufacturers"
-
 @Composable
 fun ManufacturersScreen(
     viewModel: ManufacturersViewModel,

--- a/features/search/build.gradle.kts
+++ b/features/search/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("library-android-compose")
+    kotlin("plugin.serialization")
 }
 
 android {
@@ -19,6 +20,7 @@ dependencies {
 
     implementation(libs.core.ktx)
     implementation(libs.lifecycle.viewmodel)
+    implementation(libs.serialization)
 
     testImplementation(libs.bundles.testing)
 }

--- a/features/search/src/main/java/com/dpanger/vehicles/features/search/ui/SearchRoute.kt
+++ b/features/search/src/main/java/com/dpanger/vehicles/features/search/ui/SearchRoute.kt
@@ -1,0 +1,6 @@
+package com.dpanger.vehicles.features.search.ui
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object SearchRoute

--- a/features/search/src/main/java/com/dpanger/vehicles/features/search/ui/SearchScreen.kt
+++ b/features/search/src/main/java/com/dpanger/vehicles/features/search/ui/SearchScreen.kt
@@ -5,8 +5,6 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dpanger.vehicles.features.search.viewmodel.SearchViewModel
 
-const val ROUTE_SEARCH = "search"
-
 @Composable
 fun SearchScreen(
     viewModel: SearchViewModel,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ ksp = "2.0.0-1.0.24"
 ktlint = "12.1.0"
 lifecycle = "2.8.7"
 mockk = "1.13.8"
-navigation = "2.8.7"
 serialization = "1.7.3"
 
 [libraries]
@@ -31,7 +30,6 @@ ktlint-gradle = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", vers
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 serialization-gradle = { group = "org.jetbrains.kotlin.plugin.serialization", name = "org.jetbrains.kotlin.plugin.serialization.gradle.plugin", version.ref = "kotlin" }
 
@@ -45,5 +43,4 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 [bundles]
-navigation = [ "navigation-compose", "serialization" ]
 testing = [ "junit5", "mockk", "kotest", "coroutines-test" ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ ksp = "2.0.0-1.0.24"
 ktlint = "12.1.0"
 lifecycle = "2.8.7"
 mockk = "1.13.8"
+navigation = "2.8.7"
+serialization = "1.7.3"
 
 [libraries]
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
@@ -29,6 +31,9 @@ ktlint-gradle = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", vers
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+serialization-gradle = { group = "org.jetbrains.kotlin.plugin.serialization", name = "org.jetbrains.kotlin.plugin.serialization.gradle.plugin", version.ref = "kotlin" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -37,6 +42,8 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 [bundles]
+navigation = [ "navigation-compose", "serialization" ]
 testing = [ "junit5", "mockk", "kotest", "coroutines-test" ]


### PR DESCRIPTION
Newer versions of Compose Navigation use data classes/objects to pass information rather than putting information into a route string, like a deep link path. Update all uses to the newer pattern.

Resolves #39 